### PR TITLE
#4 Expose GetDevicesAsync() method

### DIFF
--- a/client-test-app/MainPage.xaml.cs
+++ b/client-test-app/MainPage.xaml.cs
@@ -17,10 +17,13 @@ namespace ClientTestApp
         {
             this.InitializeComponent();
 
-            testClient();
+            // (Un)comment the method you need to test
+
+            //TestClient();
+            TestClientDevices();
         }
 
-        public async void testClient()
+        public async void TestClient()
         {
             Relayr.OauthToken = "YOUR OAUTH TOKEN";
             var Transmitters = await Relayr.GetTransmittersAsync();
@@ -32,6 +35,12 @@ namespace ClientTestApp
             Device d = await transmitter.SubscribeToDeviceDataAsync(devices[3]);
             d.PublishedDataReceived += d_PublishedDataReceived;
 
+        }
+
+        public async void TestClientDevices()
+        {
+            Relayr.OauthToken = "YOUR OAUTH TOKEN";
+            var devices = await Relayr.GetDevicesAsync();
         }
 
         void d_PublishedDataReceived(object sender, PublishedDataReceivedEventArgs args)

--- a/relayr-csharp-sdk/Relayr.cs
+++ b/relayr-csharp-sdk/Relayr.cs
@@ -64,6 +64,25 @@ namespace relayr_csharp_sdk
             return transmitters;
         }
 
+        public static async Task<List<dynamic>> GetDevicesAsync()
+        {
+            if (_userId == null)
+            {
+                await getUserInformation();
+            }
+
+            var response = await HttpManager.Manager.PerformHttpOperation(ApiCall.DevicesListUnderSpecificUser, new string[] { _userId }, null);
+            dynamic deviceList = await HttpManager.Manager.ConvertResponseContentToObject(response);
+            var devices = new List<dynamic>();
+
+            for (int i = 0; i < deviceList.Length; i++)
+            {
+                devices.Add(deviceList[i]);
+            }
+
+            return devices;
+        }
+
         // Try to connect to the broker using the given dynamic representation of a transmitter and
         // the specified clientID. If connection is successful, it will return a Transmitter isntance
         // representing the transmitter. Returns null otherwise.


### PR DESCRIPTION
As per issue #4, we need a way to retrieve all devices for a user. There's now a new method that allows you to do just this.